### PR TITLE
Allow initialization with all supported XM125 I2C addresses

### DIFF
--- a/src/sfTk/sfDevXM125Core.cpp
+++ b/src/sfTk/sfDevXM125Core.cpp
@@ -25,9 +25,9 @@ sfTkError_t sfDevXM125Core::init(sfTkII2C *theBus)
         return ksfTkErrBusNotInit;
 
     // Check if the provided address is valid
-    if (theBus->address() != SFE_XM125_I2C_ADDRESS)
+    if (theBus->address() != SFE_XM125_I2C_ADDRESS && theBus->address() != 0x51 && theBus->address() != 0x53){
         return ksfTkErrFail;
-
+    }
     // Sets communication bus
     _theBus = theBus;
 


### PR DESCRIPTION
init() currently only accepts SFE_XM125_I2C_ADDRESS, even though the hardware supports alternate I2C addresses (0x51 and 0x53). This prevents applications from using multiple XM125 devices configured with different addresses. This change updates the address validation to accept all supported addresses.